### PR TITLE
strip prefix with use start position

### DIFF
--- a/src/PathPrefixer.php
+++ b/src/PathPrefixer.php
@@ -29,7 +29,7 @@ final class PathPrefixer
     public function stripPrefix(string $path): string
     {
         /* @var string */
-        return substr($path, strlen($this->prefix));
+        return substr($path, strpos($path, $this->prefix) + strlen($this->prefix));
     }
 
     public function stripDirectoryPrefix(string $path): string


### PR DESCRIPTION
This fixes the problem when the absolute path is returned. This behavior is typical for WebDavAdapter.